### PR TITLE
Fix nick rules

### DIFF
--- a/Client.cpp
+++ b/Client.cpp
@@ -3,6 +3,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+#include <cctype>
 #include <cerrno>
 #include <cstring>
 #include <ctime>
@@ -122,7 +123,7 @@ void Client::nick(const std::vector<std::string> &msg) {
     return;
   }
   const std::string &nick = msg[1];
-  if (nick.find(' ') != std::string::npos) {
+  if (!Client::isValidName(nick)) {
     createMessage(Server::ERR_ERRONEUSNICKNAME, nick);
     return;
   }
@@ -353,7 +354,6 @@ void Client::names(const std::vector<std::string> &msg) {
   createMessage(Server::RPL_ENDOFNAMES);
 }
 
-
 void Client::list(const std::vector<std::string> &msg) {
   if (msg.size() > 2 && msg[2] != _server->getName()) {
     createMessage(Server::ERR_NOSUCHSERVER, msg[2]);
@@ -386,6 +386,19 @@ void Client::server_time(const std::vector<std::string> &msg) {
 }
 
 // * HELPERS *
+
+bool Client::isValidName(const std::string &name) {
+  if (name.empty() || name.length() > 50 || std::isalpha(name[0]) == 0 ||
+      name.find_first_of(" ,:") != std::string::npos) {
+    return false;
+  }
+  for (std::string::const_iterator it = name.begin(); it != name.end(); ++it) {
+    if (std::isprint(*it) == 0) {
+      return false;
+    }
+  }
+  return true;
+}
 
 void Client::removeChannel(const std::string &name) {
   Channel *channel = findChannel(_channels, name);

--- a/utils.cpp
+++ b/utils.cpp
@@ -65,7 +65,7 @@ std::vector<std::string> split(const std::string &line, char delimiter) {
 }
 
 std::vector<std::string> parse(const std::string &line) {
-  size_t const found_colon = line.find(':');
+  size_t const found_colon = line.find(" :");
   std::vector<std::string> result = split(line.substr(0, found_colon), ' ');
 
   if (found_colon != std::string::npos) {


### PR DESCRIPTION
Should be reviewed after #53.

- Introducing stricter nick rules:
  - Has to start with a letter
  - Should only contain printable ascii chars
  - Can't contain space, comma, or colon (as those are separators)

- The parser should only consider : as a separator if it is preceded with a space.